### PR TITLE
Fixes the path to default configuration file in the sublime commands file

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -3,7 +3,7 @@
         "caption": "Preferences: OpenFolder Settings - Default",
         "command": "open_file", "args":
         {
-            "file": "${packages}/OpenFolder/OpenFolder.sublime-settings"
+            "file": "${packages}/Open Folder/OpenFolder.sublime-settings"
         }
     },
     {


### PR DESCRIPTION
As the plugin is listed in Sublime Package Control with the name "Open Folder" (with space) the folder created for this plugin is that, but in the sublime-commands file the path to open the default configuration file is hard-coded as "../OpenFolder/.." instead so when the command is invoked, the file opened is incorrect (and, in fact, is an empty one)
