### PR TITLE
Renewal of plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/package-metadata.json
+*.pyc

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,16 +1,22 @@
 [
     {
         "caption": "Preferences: OpenFolder Settings - Default",
-        "command": "open_file", "args":
-        {
-            "file": "${packages}/Open Folder/OpenFolder.sublime-settings"
-        }
+        "command": "open_folder_open_settings", "args": { "scope": "default"}
+    },
+    {
+        "caption": "Preferences: OpenFolder Settings - Default (OS-Specific)",
+        "command": "open_folder_open_settings", "args": { "scope": "os"}
     },
     {
         "caption": "Preferences: OpenFolder Settings - User",
-        "command": "open_file", "args":
-        {
-            "file": "${packages}/User/OpenFolder.sublime-settings"
-        }
+        "command": "open_folder_open_settings", "args": { "scope": "user"}
+    },
+    {
+        "caption": "Preferences: OpenFolder Settings - User (Host-Specific)",
+        "command": "open_folder_open_settings", "args": { "scope": "host"}
+    },
+    {
+        "caption": "OpenFolder: Open current file's containing folder",
+        "command": "open_folder_open_current"
     }
 ]

--- a/OpenFolder (Linux).sublime-settings
+++ b/OpenFolder (Linux).sublime-settings
@@ -1,4 +1,9 @@
 // As always, please edit User.sublime-settings rather than this file.
 {
-	"file_manager": "xdg-open '{0}'"
+    "folder": {
+        "command": [
+            "xdg-open",
+            "{dirname}"
+        ]
+    }
 }

--- a/OpenFolder (OSX).sublime-settings
+++ b/OpenFolder (OSX).sublime-settings
@@ -1,4 +1,9 @@
 // As always, please edit User.sublime-settings rather than this file.
 {
-	"file_manager": "open '{0}'"
+    "folder": {
+        "command": [
+            "open",
+            "{dirname}"
+        ]
+    },
 }

--- a/OpenFolder (Windows).sublime-settings
+++ b/OpenFolder (Windows).sublime-settings
@@ -1,4 +1,17 @@
 // As always, please edit User.sublime-settings rather than this file.
 {
-	"file_manager": "explorer /e /root,\"{0}\""
+   "folder": {
+        "command": [
+            "explorer.exe",
+            "/e,/root,{dirname}"
+        ],
+        "use_shell": false
+    },
+    "file": {
+        "command": [
+            "explorer.exe",
+            "/e,/root,{dirname}","/select,{filepath}"
+        ],
+        "use_shell": false
+    }
 }

--- a/OpenFolder.py
+++ b/OpenFolder.py
@@ -177,7 +177,7 @@ class OpenFolderOpenSettings(sublime_plugin.WindowCommand):
         settingsFilePieces = self.getSettingPieces(scope)
 
         self.window.run_command("open_file", {
-            "file": "${packages}/{0}/{1}" % settingsFilePieces
+            "file": "${packages}/%0s/%1s" % settingsFilePieces
         })
 
     def getSettingPieces(self, scope):

--- a/OpenFolder.py
+++ b/OpenFolder.py
@@ -1,26 +1,118 @@
 import sublime
 import sublime_plugin
-from subprocess import call
+import subprocess
 import os
+import platform
 
+class OpenFolderClassicCommand(object):
+    def __init__(self, window, cmdline):
+        self.window = window
+        self.cmdline = cmdline
+
+    def runForFolder(self, folderPath):
+        subprocess.call(self.cmdline.format(folderPath), shell=True)
+
+    def runForFile(self, filePath):
+        self.window.run_command(
+            "open_dir",
+            {"dir": os.path.dirname(filePath), "file": os.path.basename(filePath)}
+        )
+
+class OpenFolderCommand(object):
+    def __init__(self, window, folder_command, file_command):
+        self.window = window
+        self.folder_command = folder_command
+        self.file_command = file_command
+
+    def runForFolder(self, folderPath):
+        pieces = self.parseFolder(folderPath)
+
+        if self.folder_command is None:
+            raise RuntimeError('There are not commands configurated')
+        else:
+            self.execute(self.folder_command['command'], pieces, bool(self.folder_command['use_shell']) if 'use_shell' in self.folder_command else False)
+
+    def runForFile(self, filePath):
+        pieces = self.parseFile(filePath)
+
+        if self.file_command is None:
+            if self.folder_command is not None:
+                return self.runForFolder(pieces['dirname'])
+            else:
+                raise RuntimeError('There are not commands configurated')
+        else:
+            self.execute(self.file_command['command'], pieces, bool(self.file_command['use_shell']) if 'use_shell' in self.file_command else False)
+
+    def parseFolder(self, path):
+        return {
+            'filepath': path,
+            'dirname': path,
+            'basename': ''
+        }
+
+    def parseFile(self, path):
+        return {
+            'filepath': path,
+            'dirname': os.path.dirname(path),
+            'basename': os.path.basename(path)
+        }
+
+    def execute(self, cmd, filler, use_shell):
+
+        try:
+            cmd_list = [ item.format(**filler) for item in cmd ]
+        except KeyError as err:
+            return sublime.status_message("{0} is not a valid replacement".format(err.args[0]))
+        except Exception as err:
+            return sublime.status_message(repr(err))
+
+        cwd = filler['dirname']
+
+        try:
+            subprocess.Popen(cmd_list, shell=use_shell, cwd=cwd)
+        except Exception as err:
+            sublime.status_message(repr(err))
+
+class OpenFolderHelper(object):
+    @classmethod
+    def getCommand(cls, window):
+        helper = cls()
+        classic_cmdline = helper.getSetting("file_manager")
+
+        if classic_cmdline is not None:
+            return OpenFolderClassicCommand(window, classic_cmdline)
+
+        return OpenFolderCommand(window, helper.getSetting('folder'), helper.getSetting('file'))
+
+    @classmethod
+    def getHostSettingsFilePath(cls):
+        return cls.getSettingsFilePath(platform.uname()[1])
+
+    @classmethod
+    def getSettingsFilePath(cls, special=None):
+        return "".join(("OpenFolder", " (" + special + ")" if special else "", ".sublime-settings"))
+
+    def __init__(self):
+        self.host_settings = sublime.load_settings(OpenFolderHelper.getHostSettingsFilePath())
+        self.user_settings = sublime.load_settings(OpenFolderHelper.getSettingsFilePath())
+
+    def getSetting(self, settingName, default=None):
+        return self.host_settings.get(settingName, self.user_settings.get(settingName, default))
 
 class OpenFolder(sublime_plugin.WindowCommand):
     def run(self, paths):
-        settings = sublime.load_settings("OpenFolder.sublime-settings")
-        file_manager = settings.get("file_manager", "xdg-open '{0}'")
+        command = OpenFolderHelper.getCommand(self.window)
 
         for path in paths:
             if os.path.isdir(path):
-                call(file_manager.format(path), shell=True)
+                command.runForFolder(path)
             else:
-                self.window.run_command(
-                    "open_dir",
-                    {"dir": os.path.dirname(path), "file": os.path.basename(path)}
-                )
+                command.runForFile(path)
 
     def description(self, paths):
-        settings = sublime.load_settings("OpenFolder.sublime-settings")
-        display_for_files = settings.get('display_for_files', True)
+        helper = OpenFolderHelper()
+
+        display_for_files = helper.getSetting('display_for_files', True)
 
         file_count = 0
         dir_count = 0
@@ -41,3 +133,23 @@ class OpenFolder(sublime_plugin.WindowCommand):
             return u"Open Containing Folder\u2026"
         else:
             return None
+
+
+class OpenFolderOpenSettings(sublime_plugin.WindowCommand):
+    def run(self, scope='default'):
+        if scope == 'host':
+            settingsFile = os.path.join(sublime.packages_path(), 'User', OpenFolderHelper.getHostSettingsFilePath())
+        elif scope == 'user':
+            settingsFile = os.path.join(sublime.packages_path(), 'User', OpenFolderHelper.getSettingsFilePath())
+        elif scope == 'os':
+            settingsFile = os.path.join(sublime.packages_path(), 'Open Folder', OpenFolderHelper.getSettingsFilePath(sublime.platform().capitalize()))
+        else:
+            settingsFile = os.path.join(sublime.packages_path(), 'Open Folder', OpenFolderHelper.getSettingsFilePath())
+
+        self.window.open_file(settingsFile)
+
+
+class OpenFolderOpenCurrent(sublime_plugin.TextCommand):
+    def run(self, edit):
+        if self.view.file_name() is not None:
+            self.view.window().run_command('open_folder', {'paths': [self.view.file_name()]})

--- a/OpenFolder.sublime-settings
+++ b/OpenFolder.sublime-settings
@@ -1,7 +1,5 @@
 // As always, please edit User/OpenFolder.sublime-settings rather than this file.
 {
-	"file_manager": "xdg-open",
-
 	// Indicate whether the Side Bar menu item should be displayed
 	// to open the containing folder of the selected file(s).
 	"display_for_files" : true

--- a/Tab Context.sublime-menu
+++ b/Tab Context.sublime-menu
@@ -1,3 +1,6 @@
 [
-	{ "command": "open_dir", "args": {"dir": "$file_path", "file": "$file_name"}, "caption": "Open Containing Folder…" }
+	{ 
+        "command": "open_folder_open_current", "args": {},
+        "caption": "Open Containing Folder…" 
+    }
 ]


### PR DESCRIPTION
This is basically a rewrite of the plugin, adding the following features:
- Allows to specify the command to launch using an array instead of a string. It gives better compatibility with Windows, and less quotes to write.
- Instead of using only {0} as placeholder, adds the {filepath}, {dirname} and {basename} placeholders.
- Always uses the user-specified command to open folders instead of the system one.
- Support for two distinct commands to launch when opening directly a folder, or when opening a file's containing folder.
- Support for compressed installation in ST3
- Support for being installed with any package name, not only "Open Folder"
- Usage of the recommended way subprocess.popen to launch the command, preventing Sublime Text of hanging while the file manager is open (a problem mainly in Windows)
- Drop-in replacement, if user has an old Open Folder settings file, it will work just exactly as before.
- Support for host-specific settings, more portable for usage with Package Syncing
- Palette command to open current file's containing folder 
- Palette commands to open the default (global or platform-specific) or user (global or host-specific) settings files
